### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ pip install flash-attn>=2.5.8
 
 ## Docker container
 
-If you prefer to run your experiments in a reproduceable container, you can use our pre-built docker image containing the repository and pre-installed dependencies.
+If you prefer to run your experiments in a reproducible container, you can use our pre-built docker image containing the repository and pre-installed dependencies.
 ```bash
 docker pull primeintellect/open_diloco:main
 docker run -d --name open-diloco --ipc=host --network=host --gpus=all primeintellect/open_diloco:main


### PR DESCRIPTION
## Summary
- fix spelling of `reproducible` in Docker container section of `README.md`

## Testing
- `grep -n reproducible README.md`

------
https://chatgpt.com/codex/tasks/task_e_687713d39f148333a025be6a87f1e5ce